### PR TITLE
DynamicImport追加

### DIFF
--- a/components/lv1/Timer.tsx
+++ b/components/lv1/Timer.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useState } from 'react';
+
+const Timer = () => {
+  const now = new Date();
+  const [hour, setHour] = useState(now.getHours());
+  const [min, setMin] = useState(now.getMinutes());
+  const [sec, setSec] = useState(now.getSeconds());
+  setInterval(() => {
+    const now = new Date();
+    setHour(now.getHours());
+    setMin(now.getMinutes());
+    setSec(now.getSeconds());
+  }, 1000);
+  return (
+    <>
+      <div>Timer</div>
+      <div>
+        {hour}時{min}分{sec}秒
+      </div>
+    </>
+  );
+};
+
+export default Timer;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,28 +1,17 @@
 import Head from 'next/head';
-import styles from '../styles/Home.module.css';
-import { useState, useEffect } from 'react';
+import dynamic from 'next/dynamic';
 
 const index = () => {
-  const now = new Date();
-  const [hour, setHour] = useState(now.getHours());
-  const [min, setMin] = useState(now.getMinutes());
-  const [sec, setSec] = useState(now.getSeconds());
-  setInterval(() => {
-    const now = new Date();
-    setHour(now.getHours());
-    setMin(now.getMinutes());
-    setSec(now.getSeconds());
-  }, 1000);
+  const DynamicComponentWithNoSSR = dynamic(() => import('../components/lv1/Timer'), {
+    ssr: false,
+  });
 
   return (
     <>
       <Head>
         <title>Timer</title>
       </Head>
-      <div>Timer</div>
-      <div>
-        {hour}時{min}分{sec}秒
-      </div>
+      <DynamicComponentWithNoSSR />
     </>
   );
 };


### PR DESCRIPTION
DynamicImport使ってCSRにして、現在時刻を取得した時にクライアントとサーバーのレンダリング結果がズレるのを解消しました close #6